### PR TITLE
Add AnyLogic DB helper and test

### DIFF
--- a/Database/DatabaseTest.java
+++ b/Database/DatabaseTest.java
@@ -1,0 +1,18 @@
+public class DatabaseTest {
+    public static void main(String[] args) throws Exception {
+        Databank db = new Databank();
+        db.setElectricityPrice(42.0);
+
+        try (var conn = AnyLogicDBUtil.openConnection()) {
+            AnyLogicDBUtil.createSchema(conn);
+            AnyLogicDBUtil.insertDatabank(conn, "test", db);
+
+            double price = AnyLogicDBUtil.loadElectricityPrice(conn, "test");
+            if (price == db.getElectricityPrice()) {
+                System.out.println("Test passed: price=" + price);
+            } else {
+                System.err.println("Test failed: expected " + db.getElectricityPrice() + " but got " + price);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a small `AnyLogicDBUtil` helper to demonstrate using the internal AnyLogic database
- add `DatabaseTest` with a simple check storing/retrieving a value

## Testing
- `javac Database/*.java`
- `java -cp Database DatabaseTest` *(fails: No suitable driver found for jdbc:sqlite::memory:)*

------
https://chatgpt.com/codex/tasks/task_e_6840288d7a9883229ff808765f491a0a