### PR TITLE
Add CSV import test

### DIFF
--- a/Database/DatabaseTest.java
+++ b/Database/DatabaseTest.java
@@ -1,12 +1,12 @@
+import java.io.File;
+
 public class DatabaseTest {
     public static void main(String[] args) throws Exception {
         Databank db = new Databank();
         db.setElectricityPrice(42.0);
 
-        String url = args.length > 0 ? args[0] : null;
-        try (var conn = (url != null)
-                ? AnyLogicDBUtil.openConnection(url)
-                : AnyLogicDBUtil.openHSQLDBConnection()) {
+        String url = args.length > 0 ? args[0] : "jdbc:hsqldb:mem:testdb";
+        try (var conn = AnyLogicDBUtil.openConnection(url)) {
             AnyLogicDBUtil.createSchema(conn);
             AnyLogicDBUtil.insertDatabank(conn, "test", db);
 
@@ -15,6 +15,18 @@ public class DatabaseTest {
                 System.out.println("Test passed: price=" + price);
             } else {
                 System.err.println("Test failed: expected " + db.getElectricityPrice() + " but got " + price);
+            }
+
+            // Import sample CSV file and verify row count
+            File csv = new File("sample_data.csv");
+            AnyLogicDBUtil.importTableFromFile(conn, "sample_table", csv);
+            try (var st = conn.createStatement();
+                 var rs = st.executeQuery("SELECT COUNT(*) FROM sample_table")) {
+                if (rs.next() && rs.getInt(1) == 2) {
+                    System.out.println("CSV import test passed");
+                } else {
+                    System.err.println("CSV import test failed");
+                }
             }
         }
     }

--- a/Database/sample_data.csv
+++ b/Database/sample_data.csv
@@ -1,0 +1,3 @@
+id,name,value
+1,Alice,10
+2,Bob,20


### PR DESCRIPTION
## Summary
- enhance `DatabaseTest` to load an in-memory HSQLDB by default
- add verification of automatic CSV import
- provide small sample CSV data for the test

## Testing
- `javac -cp .:hsqldb-2.7.4.jar:poi-3.0-FINAL.jar:poi-ooxml-full-5.0.0.jar *.java`
- `java -cp .:hsqldb-2.7.4.jar:poi-3.0-FINAL.jar:poi-ooxml-full-5.0.0.jar DatabaseTest`

------
https://chatgpt.com/codex/tasks/task_e_684034d47fc0832296b9ec13b26f30df