### PR TITLE
Add CSV importer for AnyLogic DB

### DIFF
--- a/Database/CsvImporter.java
+++ b/Database/CsvImporter.java
@@ -1,0 +1,21 @@
+public class CsvImporter {
+    public static void main(String[] args) {
+        if (args.length < 2 || args.length > 3) {
+            System.err.println("Usage: java CsvImporter <tableName> <csvFile> [jdbcUrl]");
+            return;
+        }
+        String tableName = args[0];
+        java.io.File csv = new java.io.File(args[1]);
+        if (!csv.isFile()) {
+            System.err.println("CSV file not found: " + csv);
+            return;
+        }
+        String url = args.length == 3 ? args[2] : null;
+        try (var conn = url == null ? AnyLogicDBUtil.openHSQLDBConnection() : AnyLogicDBUtil.openConnection(url)) {
+            AnyLogicDBUtil.importTableFromFile(conn, tableName, csv);
+            System.out.println("Imported " + csv + " into table " + tableName);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/Database/README.md
+++ b/Database/README.md
@@ -28,6 +28,18 @@ java -cp .:hsqldb-2.7.4.jar DatabaseTest
 
 If everything works you will see `Test passed` in the console.
 
+### Importing CSV files
+
+You can create a new table from any CSV file with the `CsvImporter` helper:
+
+```bash
+javac CsvImporter.java AnyLogicDBUtil.java
+java -cp .:hsqldb-2.7.4.jar CsvImporter <tableName> <file.csv> [jdbcUrl]
+```
+
+If no `jdbcUrl` is supplied, the importer connects to the local HSQLDB instance
+started above.
+
 ## Connecting from AnyLogic
 
 1. Copy `hsqldb-2.7.4.jar` into the `<AnyLogic>/lib/` directory or add it to the model's classpath.


### PR DESCRIPTION
## Summary
- add `CsvImporter` Java utility for bulk-importing CSV files into AnyLogic's DB
- document how to use the importer in the Database README

## Testing
- `javac Database/AnyLogicDBUtil.java Database/CsvImporter.java Database/Databank.java Database/WeatherData.java Database/DatabaseTest.java -cp Database/jar/hsqldb-2.7.4.jar:Database/jar/poi-3.0-FINAL.jar:Database/jar/poi-ooxml-full-5.0.0.jar`

------
https://chatgpt.com/codex/tasks/task_e_684037c393a88322aea0dac5ba82b317