### PR TITLE
Clarify automatic CSV import

### DIFF
--- a/Database/Databank.java
+++ b/Database/Databank.java
@@ -2,7 +2,6 @@ public class Databank {
     private WeatherData weatherForecast;
     private double electricityPrice;
     private double[] pvProductionCurve;
-    private double[] evConsumptionCurve;
     private double[] heatPumpConsumptionCurve;
     private double[] generalConsumptionCurve;
     private double[] batteryLoadingCurve;
@@ -35,13 +34,6 @@ public class Databank {
         this.pvProductionCurve = pvProductionCurve;
     }
 
-    public double[] getEvConsumptionCurve() {
-        return evConsumptionCurve;
-    }
-
-    public void setEvConsumptionCurve(double[] evConsumptionCurve) {
-        this.evConsumptionCurve = evConsumptionCurve;
-    }
 
     public double[] getHeatPumpConsumptionCurve() {
         return heatPumpConsumptionCurve;
@@ -78,7 +70,6 @@ public class Databank {
     public double getValue(String type, int index) {
         return switch (type) {
             case "PV" -> pvProductionCurve[index];
-            case "EV" -> evConsumptionCurve[index];
             case "HeatPump" -> heatPumpConsumptionCurve[index];
             case "General" -> generalConsumptionCurve[index];
             case "BatteryLoad" -> batteryLoadingCurve[index];

--- a/Database/README.md
+++ b/Database/README.md
@@ -1,54 +1,27 @@
 # Database Integration Guide
 
-This directory contains a small Java example showing how to store simulation data into a relational database. The same approach can be used inside an AnyLogic model.
+This directory provides a simple Java utility for importing CSV or Excel files
+into AnyLogic's built-in database. Table schemas are created automatically from
+the file headers, so no manual schema setup is required.
 
 ## Prerequisites
 
 * Java (version 8 or later)
-* [HSQLDB](https://hsqldb.org/) – the `hsqldb-2.7.4.jar` is already included
 * AnyLogic installation (Community or University edition)
+* The provided `hsqldb-2.7.4.jar` (only needed when running outside AnyLogic)
 
-## Starting the HSQLDB Server
+## Importing CSV/Excel Files
 
-1. From this folder start the HSQLDB server:
-   ```bash
-   java -cp hsqldb-2.7.4.jar org.hsqldb.server.Server \
-       --database.0 file:./database/db --dbname.0 test
-   ```
-   This starts a local database named `test` that listens on port `9001`.
-
-## Running the Example
-
-Compile and run `DatabaseTest` to create the schema and insert a sample record:
-
-```bash
-javac *.java
-java -cp .:hsqldb-2.7.4.jar DatabaseTest
-```
-
-If everything works you will see `Test passed` in the console.
-
-### Importing CSV files
-
-You can create a new table from any CSV file with the `CsvImporter` helper:
+Compile the helper classes and run `CsvImporter` to create a table from a file:
 
 ```bash
 javac CsvImporter.java AnyLogicDBUtil.java
 java -cp .:hsqldb-2.7.4.jar CsvImporter <tableName> <file.csv> [jdbcUrl]
 ```
 
-If no `jdbcUrl` is supplied, the importer connects to the local HSQLDB instance
-started above.
+If no `jdbcUrl` is supplied, the importer uses a default in-memory database.
+When running inside an AnyLogic model, pass the model's database connection URL
+to store the table directly in the model database.
 
-## Connecting from AnyLogic
-
-1. Copy `hsqldb-2.7.4.jar` into the `<AnyLogic>/lib/` directory or add it to the model's classpath.
-2. In AnyLogic, add a `Database` element to your model.
-3. In the Database properties set the connection URL to:
-   ```
-   jdbc:hsqldb:hsql://localhost:9001/test
-   ```
-   Use username `SA` with an empty password.
-4. You can then access the database through AnyLogic's built‑in blocks or via custom Java code (see `AnyLogicDBUtil`).
-
-This setup allows you to persist simulation outputs and later analyse them with SQL tools.
+You can also call `AnyLogicDBUtil.importTableFromFile` from your own code to
+perform the same operation programmatically.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Decentralized energy systems are becoming increasingly important for reducing co
 ## Core Simulation Elements
 
 1. **Seasonal solar irradiation profiles**
-2. **Electricity consumption of household, EV charging, and heat pump**
+2. **Electricity consumption of household and heat pump**
 3. **Performance curve and COP (Coefficient of Performance) of the heat pump**
 4. **Tariff model with variable feed-in and purchase prices**
 5. **Decision Variables:**
@@ -107,10 +107,11 @@ Decentralized energy systems are becoming increasingly important for reducing co
 
 ## Database Example
 
-The `Database` folder contains a small Java program that demonstrates how to
-store simulation output in an external HSQLDB instance. A step-by-step guide is
-available in [`Database/README.md`](Database/README.md). The same approach can
-be applied when connecting an AnyLogic model to a relational database.
+The `Database` folder now contains a lightweight Java utility that imports CSV
+or Excel files directly into AnyLogic's internal database. Table structures are
+created automatically from the file headers, so no manual schema definition is
+required. Usage instructions can be found in
+[`Database/README.md`](Database/README.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify in root README that database utilities auto-create tables
- simplify database README instructions to just use CsvImporter
- remove EV-related code and text

## Testing
- `javac -cp jar/poi-3.0-FINAL.jar:jar/poi-ooxml-full-5.0.0.jar *.java`
- `java -cp Database:Database/jar/poi-3.0-FINAL.jar:Database/jar/poi-ooxml-full-5.0.0.jar:Database/jar/hsqldb-2.7.4.jar DatabaseTest`


------
https://chatgpt.com/codex/tasks/task_e_6840392ce3008322ac4583c00b1e3592