### PR TITLE
Enable CSV-based table creation in AnyLogic DB

### DIFF
--- a/Database/AnyLogicDBUtil.java
+++ b/Database/AnyLogicDBUtil.java
@@ -25,7 +25,9 @@ public class AnyLogicDBUtil {
      */
     public static Connection openConnection() throws SQLException {
         // In a real AnyLogic model the JDBC URL is provided by the engine
-        return DriverManager.getConnection("jdbc:sqlite::memory:");
+        // Default to an in-memory HSQLDB instance so the code also works
+        // outside of AnyLogic without additional setup.
+        return DriverManager.getConnection("jdbc:hsqldb:mem:default");
     }
 
     /**
@@ -33,6 +35,18 @@ public class AnyLogicDBUtil {
      */
     public static Connection openConnection(String url) throws SQLException {
         return DriverManager.getConnection(url);
+    }
+
+    /**
+     * Convenience method that opens a connection using the provided JDBC URL
+     * and imports the table from the given file. The connection is closed
+     * automatically afterwards.
+     */
+    public static void importTableFromFile(String url, String tableName, File file)
+            throws SQLException, IOException {
+        try (Connection conn = openConnection(url)) {
+            importTableFromFile(conn, tableName, file);
+        }
     }
 
     /**

--- a/Database/DatabaseTest.java
+++ b/Database/DatabaseTest.java
@@ -1,8 +1,23 @@
 import java.io.File;
+import java.sql.Connection;
 
 public class DatabaseTest {
     public static void main(String[] args) throws Exception {
-
+        String url = args.length > 0 ? args[0] : "jdbc:hsqldb:mem:test";
+        // Running from the Database directory in CI, so the path is relative
+        // to the working directory
+        File csv = new File("sample_data.csv");
+        try (Connection conn = AnyLogicDBUtil.openConnection(url)) {
+            AnyLogicDBUtil.importTableFromFile(conn, "sample_table", csv);
+            try (var st = conn.createStatement();
+                 var rs = st.executeQuery("SELECT COUNT(*) FROM sample_table")) {
+                int count = rs.next() ? rs.getInt(1) : -1;
+                if (count == 2) {
+                    System.out.println("CSV import test passed");
+                } else {
+                    System.err.println("CSV import test failed: count=" + count);
+                }
+            }
         }
     }
 }

--- a/Database/README.md
+++ b/Database/README.md
@@ -23,5 +23,13 @@ If no `jdbcUrl` is supplied, the importer uses a default in-memory database.
 When running inside an AnyLogic model, pass the model's database connection URL
 to store the table directly in the model database.
 
-You can also call `AnyLogicDBUtil.importTableFromFile` from your own code to
-perform the same operation programmatically.
+You can also call `AnyLogicDBUtil.importTableFromFile` directly from your own
+code. A variant of this method accepts a JDBC URL and handles opening and
+closing the connection for you:
+
+```java
+AnyLogicDBUtil.importTableFromFile("jdbc:hsqldb:mem:test", "my_table",
+        new File("data.csv"));
+```
+
+This automatically creates the table and inserts all rows from the CSV file.


### PR DESCRIPTION
## Summary
- default DB connection now uses in-memory HSQLDB
- add helper to import a table using a JDBC URL
- update README with code snippet for the helper
- implement DatabaseTest to verify CSV import

## Testing
- `javac -cp "Database/jar/hsqldb-2.7.4.jar:Database/jar/poi-3.0-FINAL.jar:Database/jar/poi-ooxml-full-5.0.0.jar" Database/*.java PV/*.java`
- `cd Database && java -cp ".:jar/hsqldb-2.7.4.jar:jar/poi-3.0-FINAL.jar:jar/poi-ooxml-full-5.0.0.jar" DatabaseTest "jdbc:hsqldb:mem:test"`

------
https://chatgpt.com/codex/tasks/task_e_68403ed8d9a48322b12f03ff200c832a