### PR TITLE
Add CSV directory import feature

### DIFF
--- a/Database/AnyLogicDBUtil.java
+++ b/Database/AnyLogicDBUtil.java
@@ -50,6 +50,40 @@ public class AnyLogicDBUtil {
     }
 
     /**
+     * Imports all CSV files in the given directory using the file name (without
+     * extension) as the table name. Existing tables are reused.
+     */
+    public static void importTablesFromDirectory(Connection conn, File dir)
+            throws SQLException, IOException {
+        if (!dir.isDirectory()) {
+            throw new IOException(dir + " is not a directory");
+        }
+        File[] files = dir.listFiles((d, name) -> name.toLowerCase().endsWith(".csv"));
+        if (files == null) {
+            return;
+        }
+        for (File f : files) {
+            String table = f.getName();
+            int idx = table.lastIndexOf('.');
+            if (idx > 0) {
+                table = table.substring(0, idx);
+            }
+            importTableFromFile(conn, table, f);
+        }
+    }
+
+    /**
+     * Opens a connection to the given JDBC URL and imports all CSV files in the
+     * directory. The connection is closed automatically afterwards.
+     */
+    public static void importTablesFromDirectory(String url, File dir)
+            throws SQLException, IOException {
+        try (Connection conn = openConnection(url)) {
+            importTablesFromDirectory(conn, dir);
+        }
+    }
+
+    /**
      * Convenience method to connect to a running HSQLDB instance.
      * The connection string is based on the one provided in the README.
      */

--- a/Database/CsvDirImporter.java
+++ b/Database/CsvDirImporter.java
@@ -1,0 +1,30 @@
+import java.io.File;
+
+/**
+ * Command line utility that imports all CSV files in a directory into a
+ * database. Table names are derived from the file names.
+ */
+public class CsvDirImporter {
+    public static void main(String[] args) {
+        if (args.length < 1 || args.length > 2) {
+            System.err.println("Usage: java CsvDirImporter <directory> [jdbcUrl]");
+            return;
+        }
+
+        File dir = new File(args[0]);
+        if (!dir.isDirectory()) {
+            System.err.println("Not a directory: " + dir);
+            return;
+        }
+
+        String url = args.length == 2 ? args[1] : null;
+        try (var conn = url == null ? AnyLogicDBUtil.openHSQLDBConnection() :
+                AnyLogicDBUtil.openConnection(url)) {
+            AnyLogicDBUtil.importTablesFromDirectory(conn, dir);
+            System.out.println("Imported CSV files from " + dir.getPath());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}
+

--- a/Database/README.md
+++ b/Database/README.md
@@ -15,7 +15,7 @@ the file headers, so no manual schema setup is required.
 Compile the helper classes and run `CsvImporter` to create a table from a file:
 
 ```bash
-javac CsvImporter.java AnyLogicDBUtil.java
+javac CsvImporter.java CsvDirImporter.java AnyLogicDBUtil.java
 java -cp .:hsqldb-2.7.4.jar CsvImporter <tableName> <file.csv> [jdbcUrl]
 ```
 
@@ -33,3 +33,10 @@ AnyLogicDBUtil.importTableFromFile("jdbc:hsqldb:mem:test", "my_table",
 ```
 
 This automatically creates the table and inserts all rows from the CSV file.
+
+To import all CSV files from a directory at once, use `CsvDirImporter`. Table
+names are derived from the file names without the extension:
+
+```bash
+java -cp .:hsqldb-2.7.4.jar CsvDirImporter path/to/csv/dir [jdbcUrl]
+```


### PR DESCRIPTION
## Summary
- add utility to import all CSVs from a directory
- extend AnyLogicDBUtil with methods to bulk-import CSV files
- document the new CsvDirImporter tool

## Testing
- `javac -cp jar/hsqldb-2.7.4.jar:jar/poi-3.0-FINAL.jar:jar/poi-ooxml-full-5.0.0.jar *.java`
- `java -cp .:jar/hsqldb-2.7.4.jar DatabaseTest`
- `java -cp .:jar/hsqldb-2.7.4.jar CsvDirImporter . jdbc:hsqldb:mem:test`

------
https://chatgpt.com/codex/tasks/task_e_6840413674948322b23ea6fe6e74dcc9