### PR TITLE
Fix timestamp column mismatch

### DIFF
--- a/Database/AnyLogicDBUtil.java
+++ b/Database/AnyLogicDBUtil.java
@@ -367,10 +367,30 @@ public class AnyLogicDBUtil {
                                                  String tableName,
                                                  Timestamp startTime,
                                                  Timestamp endTime) throws SQLException {
+        return getDataAtTimeStampRange(conn, tableName, "zeitstempel", startTime, endTime);
+    }
+
+    /**
+     * Retrieves the sum of the "kwh" column between the given timestamps using
+     * a custom timestamp column.
+     *
+     * @param conn            Active database connection
+     * @param tableName       Name of the table
+     * @param timestampColumn Name of the timestamp column
+     * @param startTime       Start of the interval (inclusive)
+     * @param endTime         End of the interval (inclusive)
+     * @return Sum of the "kwh" column in the interval
+     */
+    public static double getDataAtTimeStampRange(Connection conn,
+                                                 String tableName,
+                                                 String timestampColumn,
+                                                 Timestamp startTime,
+                                                 Timestamp endTime) throws SQLException {
         String sanitizedTable = sanitizeTableName(tableName);
         String sanitizedColumn = sanitizeColumnName("kwh");
+        String sanitizedTimeColumn = sanitizeColumnName(timestampColumn);
         String sql = "SELECT SUM(" + sanitizedColumn + ") FROM " + sanitizedTable +
-                " WHERE zeitstempel >= ? AND zeitstempel <= ?";
+                " WHERE " + sanitizedTimeColumn + " >= ? AND " + sanitizedTimeColumn + " <= ?";
 
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setTimestamp(1, startTime);

--- a/Database/DatabaseController.java
+++ b/Database/DatabaseController.java
@@ -27,7 +27,8 @@ public class DatabaseController {
             Timestamp startTime = Timestamp.valueOf("2005-01-01 09:30:00");
             Timestamp endTime = Timestamp.valueOf("2005-01-01 15:40:00");
 
-            AnyLogicDBUtil.getDataAtTimeStampRange(conn, "sample_csv", startTime, endTime);
+            // sample_csv.csv uses the column name "zeit" for timestamps
+            AnyLogicDBUtil.getDataAtTimeStampRange(conn, "sample_csv", "zeit", startTime, endTime);
         }catch(Exception e){
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
- allow specifying the timestamp column in `getDataAtTimeStampRange`
- adjust `DatabaseController` to use the `zeit` column from `sample_csv`

## Testing
- `javac -cp .:Database/jar/hsqldb-2.7.4.jar:Database/jar/poi-5.2.3.jar:Database/jar/poi-ooxml-5.2.3.jar:Database/jar/poi-ooxml-full-5.2.3.jar:Database/jar/poi-ooxml-lite-5.2.3.jar:Database/jar/poi-scratchpad-5.2.3.jar:Database/jar/poi-examples-5.2.3.jar:Database/jar/poi-excelant-5.2.3.jar:junit-4.13.2.jar:hamcrest-core-1.3.jar Database/*.java`
- `java -cp .:Database:Database/jar/hsqldb-2.7.4.jar:Database/jar/poi-5.2.3.jar:Database/jar/poi-ooxml-5.2.3.jar:Database/jar/poi-ooxml-full-5.2.3.jar:Database/jar/poi-ooxml-lite-5.2.3.jar:Database/jar/poi-scratchpad-5.2.3.jar:Database/jar/poi-examples-5.2.3.jar:Database/jar/poi-excelant-5.2.3.jar:junit-4.13.2.jar:hamcrest-core-1.3.jar org.junit.runner.JUnitCore AnyLogicDBUtilTest`


------
https://chatgpt.com/codex/tasks/task_e_684c39e37c6483229dc3efb2529aede7