### PR TITLE
Add Docker importer service

### DIFF
--- a/Database/DockerFile/docker-compose.yml
+++ b/Database/DockerFile/docker-compose.yml
@@ -13,5 +13,18 @@ services:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=password
 
+  importer:
+    build:
+      context: ../..
+      dockerfile: Database/Python/Dockerfile
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: user
+      DB_PASSWORD: password
+      DB_NAME: simdata
+
 volumes:
   postgres_data:

--- a/Database/Python/Dockerfile
+++ b/Database/Python/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+# Install Python dependencies
+WORKDIR /app
+
+COPY Database/Python/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY Database/Python/main.py ./main.py
+
+# Copy CSV data used by the script
+COPY CSV ./CSV
+
+# Default environment variables (can be overridden by docker-compose)
+ENV DB_HOST=db \
+    DB_PORT=5432 \
+    DB_USER=user \
+    DB_PASSWORD=password \
+    DB_NAME=simdata
+
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- set up Dockerfile for running Python importer script
- expand docker-compose to build importer image and run main.py

## Testing
- `python3 -m py_compile Database/Python/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68529fc1bd4483228f90047127254ecf