### PR TITLE
Add documentation to Database folder

### DIFF
--- a/Database/DBAbfrage.java
+++ b/Database/DBAbfrage.java
@@ -1,9 +1,22 @@
+/**
+ * Beispielprogramm zum Zugriff auf eine PostgreSQL-Datenbank.
+ * Demonstriert einfache Abfragen für Zeitreihendaten, wie sie durch
+ * das Python-Importskript bereitgestellt werden.
+ *
+ * Diese Klasse kann eigenständig ausgeführt werden.
+ */
+
 import java.sql.*;
 import java.time.*;
 import java.util.*;
 
 public class DBAbfrage {
 
+    /**
+     * Kleine Hilfsklasse zum Aufbau und automatischen Schliessen einer JDBC-Verbindung.
+     * Standardwerte fuer URL, Benutzername und Passwort koennen ueber Parameter
+     * angepasst werden.
+     */
     // Vereinfachte Datenbank-Verbindung mit Builder-Pattern
     public static class DBConnection implements AutoCloseable {
         private Connection connection;

--- a/Database/DockerFile/docker-compose.yml
+++ b/Database/DockerFile/docker-compose.yml
@@ -1,3 +1,6 @@
+# Beispielhafte Docker-Compose-Konfiguration zum Start einer lokalen PostgreSQL-Datenbank
+# und des Python-Importdienstes.
+
 version: '3.8'
 
 services:

--- a/Database/Python/Dockerfile
+++ b/Database/Python/Dockerfile
@@ -1,3 +1,6 @@
+# Dockerfile fuer das Python-Importskript
+# Erstellt ein schlankes Image und installiert alle benoetigten Abhaengigkeiten
+
 FROM python:3.11-slim
 
 # Install Python dependencies

--- a/Database/Python/main.py
+++ b/Database/Python/main.py
@@ -1,3 +1,9 @@
+"""
+Hilfsskript zum Importieren von CSV-Dateien in eine PostgreSQL-Datenbank.
+Wird in der Docker-Umgebung automatisch gestartet und kann auch
+standalone ausgefuehrt werden.
+"""
+
 import os
 import time
 import pandas as pd

--- a/Database/Python/oldi/DBAbfrage.java
+++ b/Database/Python/oldi/DBAbfrage.java
@@ -1,3 +1,9 @@
+/**
+ * Legacy-Version des Datenbank-Demo-Programms.
+ * Zeigt grundsaetzlich die gleichen Funktionen wie die aktuelle DBAbfrage,
+ * wurde jedoch fuer erste Tests entwickelt und bleibt hier als Referenz.
+ */
+
 package Python.oldi;
 
 import java.sql.Connection;

--- a/Database/Python/transform.py
+++ b/Database/Python/transform.py
@@ -1,3 +1,8 @@
+"""
+Werkzeug zur Vorverarbeitung von CSV-Dateien bevor sie importiert werden.
+Beispielhaft wird eine Zeitstempelspalte angepasst und unnoetige Spalten werden entfernt.
+"""
+
 import pandas as pd
 
 def transformiere_zeitstempel(df: pd.DataFrame, spaltenname: str = 'utc_timestamp') -> pd.DataFrame:

--- a/Database/README.md
+++ b/Database/README.md
@@ -1,0 +1,23 @@
+# Database Utilities
+
+Dieses Verzeichnis enthaelt Hilfsprogramme zur Speicherung und Verarbeitung von CSV-Daten in einer PostgreSQL-Datenbank. Die Tools koennen unabhaengig von AnyLogic genutzt werden, um Messreihen in eine Datenbank zu importieren und spaeter wieder auszulesen.
+
+## Struktur
+
+- **DBAbfrage.java** – Java-Programm zum Einlesen von Zeitreihen und einfachen Abfragen.
+- **DockerFile/** – `docker-compose.yml` zum Starten einer lokalen PostgreSQL-Datenbank und des Import-Skripts.
+- **Python/** – Python-Skripte und Dockerfile fuer den CSV-Import.
+- **jar/** – Enthält das PostgreSQL-JDBC-Driver-JAR, das fuer die Java-Programme benoetigt wird.
+
+## Verwendung
+
+1. `docker-compose` im Unterordner `DockerFile` startet eine PostgreSQL-Datenbank und fuehrt das Python-Importskript aus:
+   ```bash
+   cd Database/DockerFile
+   docker-compose up
+   ```
+2. Das Python-Skript `main.py` importiert die in `IMPORTS_CONFIG` aufgelisteten CSV-Dateien in die Datenbank.
+3. `DBAbfrage.java` demonstriert, wie Daten aus der Datenbank abgefragt und verarbeitet werden koennen.
+
+Weitere Details zu den einzelnen Dateien finden sich in den Kommentarblöcken der jeweiligen Quellcodes.
+


### PR DESCRIPTION
## Summary
- document Database folder and add a usage README
- provide header comments in Java and Python utilities
- add short explanations in Dockerfile and docker-compose

## Testing
- `python -m py_compile Database/Python/main.py Database/Python/transform.py`
- `javac -cp Database/jar/postgresql-42.7.7.jar Database/DBAbfrage.java Database/Python/oldi/DBAbfrage.java`


------
https://chatgpt.com/codex/tasks/task_e_68530ec5f69c8322be8a9eba12f59ce0